### PR TITLE
Set sensitive outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+ * issue #1: Add `sensitive = true` argument to outputs of authorization rules. (for reference: (https://github.com/claranet/terraform-azurerm-eventhub/issues/1 ))
+
 # v7.3.0 - 2023-09-08
 
 Breaking

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,16 +60,19 @@ output "namespace_default_secondary_key" {
 output "namespace_listen_authorization_rule" {
   description = "Event Hub Namespace listen only authorization rule."
   value       = try(azurerm_eventhub_namespace_authorization_rule.listen["enabled"], null)
+  sensitive   = true
 }
 
 output "namespace_send_authorization_rule" {
   description = "Event Hub Namespace send only authorization rule."
   value       = try(azurerm_eventhub_namespace_authorization_rule.send["enabled"], null)
+  sensitive   = true
 }
 
 output "namespace_manage_authorization_rule" {
   description = "Event Hub Namespace manage authorization rule."
   value       = try(azurerm_eventhub_namespace_authorization_rule.manage["enabled"], null)
+  sensitive   = true
 }
 
 output "consumer_groups" {


### PR DESCRIPTION
Fixes #(issue) .

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- adding `sensitive = true` arguments to outputs of authorisation rules

@claranet/fr-azure-reviewers
